### PR TITLE
Export duration interface from definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-interface Duration {
+export interface Duration {
   years?: number;
   months?: number;
   days?: number;


### PR DESCRIPTION
I am using this lib but the Duration interface is not currently exported. I parse a duration code in my project within a function and want to describe the return type of that function as `Duration` but as it is not exported, I do not have access to the type.

e.g.

```
import { parse, Duration } from 'iso8601-duration';
// ^ Complains, no exported member - Duration

export const emptyDuration: Duration = {};

export const parseDuration = (durationCode?: string): Duration => {
  if (!durationCode) {
    return emptyDuration;
  }
  try {
    return parse(durationCode);
  } catch {
    console.warn('Failed to parse durationCode: ', durationCode);
    return emptyDuration;
  }
};
```