### PR TITLE
Wrap parse in try/catch

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,9 @@ export const parse = durationString => {
     return durationString.match(pattern).slice(1).reduce((prev, next, idx) => {
       prev[objMap[idx]] = parseFloat(next) || 0
       return prev
-    }, {});
-  } catch {
-    return {};
+    }, {})
+  } catch (e) {
+    return {}
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,10 +27,14 @@ export const pattern = new RegExp(iso8601)
  */
 export const parse = durationString => {
   // Slice away first entry in match-array
-  return durationString.match(pattern).slice(1).reduce((prev, next, idx) => {
-    prev[objMap[idx]] = parseFloat(next) || 0
-    return prev
-  }, {})
+  try {
+    return durationString.match(pattern).slice(1).reduce((prev, next, idx) => {
+      prev[objMap[idx]] = parseFloat(next) || 0
+      return prev
+    }, {});
+  } catch {
+    return {};
+  }
 }
 
 /**

--- a/test/iso8601-tests.js
+++ b/test/iso8601-tests.js
@@ -26,19 +26,19 @@ test('Parse: correctly parses weeks format', t => {
 test('Parse: handles undefined input', t => {
   const time = parse()
 
-  t.is(time, {})
+  t.deepEqual(time, {})
 })
 
 test('Parse: handles empty string', t => {
   const time = parse('')
 
-  t.is(time, {})
+  t.deepEqual(time, {})
 })
 
 test('Parse: handles non-iso8601 string', t => {
   const time = parse('GarBidg3')
 
-  t.is(time, {})
+  t.deepEqual(time, {})
 })
 
 test('end: returns the following day', t => {

--- a/test/iso8601-tests.js
+++ b/test/iso8601-tests.js
@@ -23,6 +23,24 @@ test('Parse: correctly parses weeks format', t => {
   t.is(time.seconds, 0)
 })
 
+test('Parse: handles undefined input', t => {
+  const time = parse()
+
+  t.is(time, {})
+})
+
+test('Parse: handles empty string', t => {
+  const time = parse('')
+
+  t.is(time, {})
+})
+
+test('Parse: handles non-iso8601 string', t => {
+  const time = parse('GarBidg3')
+
+  t.is(time, {})
+})
+
 test('end: returns the following day', t => {
   const now = new Date()
   const then = end(parse('P1D'), now)


### PR DESCRIPTION
Parse will throw an exception with invalid input (durationString is undefined | empty | invalid iso string). Wrapping in try/catch will handle these gracefully.