### PR TITLE
 Fix issue with time calculation in toSeconds (one millisecond off)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export const end = (duration, startDate) => {
 export const toSeconds = (duration, startDate) => {
   const timestamp = (startDate ? startDate.getTime() : Date.now())
   const now = new Date(timestamp)
-  const then = end(duration, startDate)
+  const then = end(duration, now)
 
   const seconds = (then.getTime() - now.getTime()) / 1000
   return seconds

--- a/test/iso8601-tests.js
+++ b/test/iso8601-tests.js
@@ -93,3 +93,20 @@ test('usage example test', t => {
   t.is(result.foo.duration, 3600 + (30 * 60) + 25)
   t.is(result.bar.duration, (43 * 60) + 58.72)
 })
+
+test('expose vulnerable time calculation in toSeconds', t => {
+  const dur = {
+    weeks: 0,
+    years: 0,
+    months: 0,
+    days: 0,
+    hours: 0,
+    minutes: 0,
+    seconds: 0
+  }
+
+  Array.from({ length: 10000 }, () => {
+    const sec = toSeconds(dur)
+    t.is(sec, 0)
+  })
+})


### PR DESCRIPTION
Date.now() might sporadically differ in toSeconds() and end().