### PR TITLE
Allowing optional duration values in toSeconds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,16 @@ const timePattern = `T(${numbers}H)?(${numbers}M)?(${numbers}S)?`
 const iso8601 = `P(?:${weekPattern}|${datePattern}(?:${timePattern})?)`
 const objMap = ['weeks', 'years', 'months', 'days', 'hours', 'minutes', 'seconds']
 
+const defaultDuration = Object.freeze({
+  years: 0,
+  months: 0,
+  weeks: 0,
+  days: 0,
+  hours: 0,
+  minutes: 0,
+  seconds: 0
+})
+
 /**
  * The ISO8601 regex for matching / testing durations
  */
@@ -41,19 +51,21 @@ export const parse = durationString => {
  * @return {Date} - The resulting end Date
  */
 export const end = (duration, startDate) => {
+  duration = Object.assign({}, defaultDuration, duration)
+
   // Create two equal timestamps, add duration to 'then' and return time difference
   const timestamp = (startDate ? startDate.getTime() : Date.now())
   const then = new Date(timestamp)
 
-  then.setFullYear(then.getFullYear() + (duration.years || 0))
-  then.setMonth(then.getMonth() + (duration.months || 0))
-  then.setDate(then.getDate() + (duration.days || 0))
-  then.setHours(then.getHours() + (duration.hours || 0))
-  then.setMinutes(then.getMinutes() + (duration.minutes || 0))
+  then.setFullYear(then.getFullYear() + duration.years)
+  then.setMonth(then.getMonth() + duration.months)
+  then.setDate(then.getDate() + duration.days)
+  then.setHours(then.getHours() + duration.hours)
+  then.setMinutes(then.getMinutes() + duration.minutes)
   // Then.setSeconds(then.getSeconds() + duration.seconds);
-  then.setMilliseconds(then.getMilliseconds() + ((duration.seconds || 0) * 1000))
+  then.setMilliseconds(then.getMilliseconds() + (duration.seconds * 1000))
   // Special case weeks
-  then.setDate(then.getDate() + ((duration.weeks || 0) * 7))
+  then.setDate(then.getDate() + (duration.weeks * 7))
 
   return then
 }
@@ -66,6 +78,8 @@ export const end = (duration, startDate) => {
  * @return {Number}
  */
 export const toSeconds = (duration, startDate) => {
+  duration = Object.assign({}, defaultDuration, duration)
+
   const timestamp = (startDate ? startDate.getTime() : Date.now())
   const now = new Date(timestamp)
   const then = end(duration, now)

--- a/src/index.js
+++ b/src/index.js
@@ -45,15 +45,15 @@ export const end = (duration, startDate) => {
   const timestamp = (startDate ? startDate.getTime() : Date.now())
   const then = new Date(timestamp)
 
-  then.setFullYear(then.getFullYear() + duration.years)
-  then.setMonth(then.getMonth() + duration.months)
-  then.setDate(then.getDate() + duration.days)
-  then.setHours(then.getHours() + duration.hours)
-  then.setMinutes(then.getMinutes() + duration.minutes)
+  then.setFullYear(then.getFullYear() + (duration.years || 0))
+  then.setMonth(then.getMonth() + (duration.months || 0))
+  then.setDate(then.getDate() + (duration.days || 0))
+  then.setHours(then.getHours() + (duration.hours || 0))
+  then.setMinutes(then.getMinutes() + (duration.minutes || 0))
   // Then.setSeconds(then.getSeconds() + duration.seconds);
-  then.setMilliseconds(then.getMilliseconds() + (duration.seconds * 1000))
+  then.setMilliseconds(then.getMilliseconds() + ((duration.seconds || 0) * 1000))
   // Special case weeks
-  then.setDate(then.getDate() + (duration.weeks * 7))
+  then.setDate(then.getDate() + ((duration.weeks || 0) * 7))
 
   return then
 }

--- a/test/iso8601-tests.js
+++ b/test/iso8601-tests.js
@@ -122,3 +122,11 @@ test('expose vulnerable time calculation in toSeconds', t => {
     t.is(sec, 0)
   })
 })
+
+test('optional arguments for time calculation in toSeconds', t => {
+  const sec = toSeconds({
+    minutes: 3
+  })
+
+  t.is(sec, 180)
+})


### PR DESCRIPTION
## Motivation

Typescript declaration mentions that each of `Duration`s interface properties is optional but the case in the code it's not the same. Thus not allowing you to use `toSeconds` as a standalone function without all of the properties present in the object.

### Before change

```javascript
toSeconds({ minutes: 3 }); // NaN
toSeconds({ minutes: 3, years: 0, months: 0, days: 0, hours: 0, seconds: 0, weeks: 0 }); // 180
```

### After change

```javascript
toSeconds({ minutes: 3 }); // 180
toSeconds({ minutes: 3, years: 0, months: 0, days: 0, hours: 0, seconds: 0, weeks: 0 }); // 180
```

---

I know this library servers another purpose but as it already contains such functionality and it is exposed to the user, why not make it as simple as possible and require as small object as possible to calculate the value.