### PR TITLE
Fix matching pattern to not match only P or PT

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,9 @@ var numbers = '\\d+(?:[\\.,]\\d+)?';
 var weekPattern = '(' + numbers + 'W)';
 var datePattern = '(' + numbers + 'Y)?(' + numbers + 'M)?(' + numbers + 'D)?';
 var timePattern = 'T(' + numbers + 'H)?(' + numbers + 'M)?(' + numbers + 'S)?';
+var lookahead = '(?=' + numbers + 'W|' + numbers + '[YMD]|T' + numbers + '[HMS])';
 
-var iso8601 = 'P(?:' + weekPattern + '|' + datePattern + '(?:' + timePattern + ')?)';
+var iso8601 = 'P' + lookahead + '(?:' + weekPattern + '|' + datePattern + '(?:' + timePattern + ')?)';
 var objMap = ['weeks', 'years', 'months', 'days', 'hours', 'minutes', 'seconds'];
 
 var defaultDuration = Object.freeze({

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,9 @@ const numbers = '\\d+(?:[\\.,]\\d+)?'
 const weekPattern = `(${numbers}W)`
 const datePattern = `(${numbers}Y)?(${numbers}M)?(${numbers}D)?`
 const timePattern = `T(${numbers}H)?(${numbers}M)?(${numbers}S)?`
+const lookahead = `(?=${numbers}W|${numbers}[YMD]|T${numbers}[HMS])`
 
-const iso8601 = `P(?:${weekPattern}|${datePattern}(?:${timePattern})?)`
+const iso8601 = `P${lookahead}(?:${weekPattern}|${datePattern}(?:${timePattern})?)`
 const objMap = ['weeks', 'years', 'months', 'days', 'hours', 'minutes', 'seconds']
 
 const defaultDuration = Object.freeze({

--- a/test/iso8601-tests.js
+++ b/test/iso8601-tests.js
@@ -35,6 +35,29 @@ test('parse: allow any number of decimals', t => {
   t.is(time.seconds, 16.239999)
 })
 
+test('parse: disallow parsing P only', t => {
+  // P and PT only fail.
+  t.false(pattern.test('P'))
+  t.false(pattern.test('PT'))
+
+  // But weeks or other correct ones pass.
+  t.true(pattern.test('P1W'))
+  t.true(pattern.test('P1Y'))
+  t.true(pattern.test('P1M'))
+  t.true(pattern.test('P1D'))
+  t.true(pattern.test('P1Y1M'))
+  t.true(pattern.test('P1Y1D'))
+  t.true(pattern.test('P1M1D'))
+  t.true(pattern.test('P1Y1M1D'))
+  t.true(pattern.test('PT1H'))
+  t.true(pattern.test('PT1M'))
+  t.true(pattern.test('PT1S'))
+  t.true(pattern.test('PT1H1M'))
+  t.true(pattern.test('PT1H1S'))
+  t.true(pattern.test('PT1H1M1S'))
+  t.true(pattern.test('P1Y1M1DT1H1M1S'))
+})
+
 test('end: returns the following day', t => {
   const now = new Date()
   const then = end(parse('P1D'), now)


### PR DESCRIPTION
This PR modifies the duration matching pattern to include a positive lookahead to prevent matching `P` or `PT` only, which are not valid durations.
That way, at least one of the groups (weeks, years|months|days, hours|minutes|seconds) has to be present.

Is this a breaking change?

Closes #21 