### PR TITLE
Test against proposal-temporal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "prettier --write .",
     "test": "npm run lint && npm run unittests",
     "unittests": "uvu -r ts-node/register test",
-    "watch": "onchange '**/*.js' -- npm run test",
+    "tdd": "onchange '**/*.ts' -- npm run unittests",
     "compile": "tsc",
     "prepublishOnly": "npm run compile",
     "release-patch": "npx np patch",
@@ -36,6 +36,7 @@
   "devDependencies": {
     "onchange": "^3.3.0",
     "prettier": "^2.6.2",
+    "proposal-temporal": "^0.9.0",
     "ts-node": "^10.7.0",
     "typescript": "4.6.3",
     "uvu": "^0.5.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,10 +84,10 @@ export const end = (durationInput: Duration, startDate = new Date()) => {
   then.setFullYear(then.getFullYear() + duration.years);
   then.setMonth(then.getMonth() + duration.months);
   then.setDate(then.getDate() + duration.days);
-  then.setHours(then.getHours() + duration.hours);
-  then.setMinutes(then.getMinutes() + duration.minutes);
-  // Then.setSeconds(then.getSeconds() + duration.seconds);
-  then.setMilliseconds(then.getMilliseconds() + duration.seconds * 1000);
+  // set time as milliseconds to get fractions working for minutes/hours
+  const hoursInMs = duration.hours * 3600 * 1000;
+  const minutesInMs = duration.minutes * 60 * 1000;
+  then.setMilliseconds(then.getMilliseconds() + duration.seconds * 1000 + hoursInMs + minutesInMs);
   // Special case weeks
   then.setDate(then.getDate() + duration.weeks * 7);
 

--- a/test/iso8601-tests.ts
+++ b/test/iso8601-tests.ts
@@ -14,6 +14,7 @@ const tryCatch = (cb) => {
 }
 
 test("Validate against Temporal.Duration", () => {
+
   // needed for calendar correctness
   const relativeDate = new Date();
   // ok patterns
@@ -21,6 +22,8 @@ test("Validate against Temporal.Duration", () => {
     "P0D",
     "PT0S",
     "PT0,1S", // commas as separators
+    "PT0.5M",
+    "PT0.5H",
     "PT0.001S",
     "P1DT2H3M4S",
     "P2Y4M6DT14H30M20.42S"

--- a/test/type-tests.ts
+++ b/test/type-tests.ts
@@ -1,9 +1,0 @@
-import iso8601, { parse, toSeconds, end, pattern } from "../src/index";
-
-// Simple typescript compile test, not actually run as a test
-
-iso8601.parse("P1Y2M4DT20H44M12.67S");
-const duration = parse("P1Y2M4DT20H44M12.67S");
-const seconds = toSeconds(duration);
-const endDate = end(duration);
-const isIso8601Date = pattern.test("P1Y2M4DT20H44M12.67S");


### PR DESCRIPTION
Add tests against [proposal-temporal](https://tc39.es/proposal-temporal/docs/duration.html)

Attempt to solve most current issues by doing what ☝️  is doing

- throw RangeError on invalid input to `parse` (`["", "P", "PT", "PT0.5H0.5S"]`)
- fixes fractional minutes/hours in `toSeconds`
- ...