### PR TITLE
Account for timezone offset between times

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,8 +102,13 @@ export const toSeconds = (durationInput: Duration, startDate = new Date()) => {
   const now = new Date(timestamp);
   const then = end(duration, now);
 
+  // Account for timezone offset between start and end date
+  const tzStart = startDate.getTimezoneOffset();
+  const tzEnd = then.getTimezoneOffset();
+  let tzOffsetSeconds = (tzStart - tzEnd) * 60;
+
   const seconds = (then.getTime() - now.getTime()) / 1000;
-  return seconds;
+  return seconds + tzOffsetSeconds;
 };
 
 export default {


### PR DESCRIPTION
Tests were failing against Temporal since I did not account for timezone offsets between start and end time.

Specifically durations that span a summertime/wintertime shift were off by 1h.