### PR TITLE
feat: add toMilliseconds method

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,12 @@ If a date is not provided for `toSeconds` the timestamp `Date.now()` is used as 
 ### Interface
 
 ```js
+export const toMilliseconds; // fn = (obj, date?) => number
 export const toSeconds; // fn = (obj, date?) => number
 export const pattern;   // ISO 8601 RegExp
 export const parse;     // fn = string => obj
 export default {
+  toMilliseconds
 	toSeconds,
 	pattern,
 	parse
@@ -71,7 +73,7 @@ export default {
 Simple usage
 
 ```js
-import { parse, end, toSeconds, pattern } from "iso8601-duration";
+import { parse, end, toMilliseconds, toSeconds, pattern } from "iso8601-duration";
 
 console.log(parse("P1Y2M4DT20H44M12.67S"));
 /* outputs =>
@@ -84,6 +86,9 @@ console.log(parse("P1Y2M4DT20H44M12.67S"));
 	seconds: 12.67
 }
 */
+
+console.log(toMilliseconds(parse("PT1H30M10.5S")));
+// outputs => 5410500
 
 console.log(toSeconds(parse("PT1H30M10.5S")));
 // outputs => 5410.5

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -20,8 +20,11 @@ export declare const parse: (durationString: string) => Duration;
 export declare const end: (durationInput: Duration, startDate?: Date) => Date;
 /** Convert ISO8601 duration object to seconds */
 export declare const toSeconds: (durationInput: Duration, startDate?: Date) => number;
+/** Convert ISO8601 duration object to seconds */
+export declare const toMilliseconds: (durationInput: Duration, startDate?: Date) => number;
 declare const _default: {
     end: (durationInput: Duration, startDate?: Date) => Date;
+    toMilliseconds: (durationInput: Duration, startDate?: Date) => number;
     toSeconds: (durationInput: Duration, startDate?: Date) => number;
     pattern: RegExp;
     parse: (durationString: string) => Duration;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
  * @description A module for parsing ISO8601 durations
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.toSeconds = exports.end = exports.parse = exports.pattern = void 0;
+exports.toMilliseconds = exports.toSeconds = exports.end = exports.parse = exports.pattern = void 0;
 /**
  * The pattern used for parsing ISO8601 duration (PnYnMnWnDTnHnMnS).
  */
@@ -90,8 +90,16 @@ var toSeconds = function (durationInput, startDate) {
     return seconds + tzOffsetSeconds;
 };
 exports.toSeconds = toSeconds;
+/** Convert ISO8601 duration object to seconds */
+var toMilliseconds = function (durationInput, startDate) {
+    if (startDate === void 0) { startDate = new Date(); }
+    var seconds = (0, exports.toSeconds)(durationInput, startDate);
+    return seconds * 1000;
+};
+exports.toMilliseconds = toMilliseconds;
 exports.default = {
     end: exports.end,
+    toMilliseconds: exports.toMilliseconds,
     toSeconds: exports.toSeconds,
     pattern: exports.pattern,
     parse: exports.parse,

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,8 +117,18 @@ export const toSeconds = (
   return seconds + tzOffsetSeconds;
 };
 
+/** Convert ISO8601 duration object to seconds */
+export const toMilliseconds = (
+  durationInput: Duration,
+  startDate: Date = new Date(),
+): number => {
+  const seconds = toSeconds(durationInput, startDate);
+  return seconds * 1000;
+};
+
 export default {
   end,
+  toMilliseconds,
   toSeconds,
   pattern,
   parse,

--- a/test/iso8601-tests.mjs
+++ b/test/iso8601-tests.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { end, parse, pattern, toSeconds } from "../lib/index.js";
+import {
+  end,
+  parse,
+  pattern,
+  toMilliseconds,
+  toSeconds,
+} from "../lib/index.js";
 
 import { Temporal } from "@js-temporal/polyfill";
 
@@ -123,6 +129,40 @@ test("toSeconds: with supplied start date", () => {
   // Act
   const durFromJan = toSeconds(parse("P1M1D"), firstOfJanuary);
   const durFromFeb = toSeconds(parse("P1M1D"), firstOfFebruary);
+
+  // Assert
+  assert.ok(durFromJan > durFromFeb);
+  assert.equal(durFromJan, expectedJanDuration);
+  assert.equal(durFromFeb, expectedFebDuration);
+});
+
+test("toMilliseconds: returns simple HMS time in total milliseconds", () => {
+  const res = toMilliseconds(parse("PT1H2M5.512S"));
+  const expected = (3600 + 2 * 60 + 5.512) * 1000;
+  assert.equal(res, expected);
+});
+
+test("toMilliseconds: return weeks in total milliseconds", () => {
+  const res = toMilliseconds(parse("P3W"));
+  const timestamp = Date.now();
+  const d = new Date(timestamp);
+  d.setDate(d.getDate() + 7 * 3);
+  const expected = d.getTime() - new Date(timestamp).getTime();
+  assert.equal(res, expected);
+});
+
+test("toMilliseconds: with supplied start date", () => {
+  // Arrange
+  const firstOfJanuary = new Date(2016, 0, 1);
+  const firstOfFebruary = new Date(2016, 1, 1);
+  const expectedJanDuration =
+    new Date(2016, 1, 2).getTime() - new Date(2016, 0, 1).getTime();
+  const expectedFebDuration =
+    new Date(2016, 2, 2).getTime() - new Date(2016, 1, 1).getTime();
+
+  // Act
+  const durFromJan = toMilliseconds(parse("P1M1D"), firstOfJanuary);
+  const durFromFeb = toMilliseconds(parse("P1M1D"), firstOfFebruary);
 
   // Assert
   assert.ok(durFromJan > durFromFeb);


### PR DESCRIPTION
Create a method for converting duration object to milliseconds.

The new `toMilliseconds` method uses the already existing `toSeconds` method, but also multiplies by 1000 to convert it to milliseconds instead of seconds.
