### PR TITLE
fix: reject decimal fraction on non-final duration unit (ISO 8601)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,9 +46,16 @@ var parse = function (durationString) {
     if (slicedMatches.filter(function (v) { return v != null; }).length === 0) {
         throw new RangeError("invalid duration: ".concat(durationString));
     }
-    // Check only one fraction is used
-    if (slicedMatches.filter(function (v) { return /\./.test(v || ""); }).length > 1) {
-        throw new RangeError("only the smallest unit can be fractional");
+    // A fraction is only allowed on the last present (smallest) unit
+    var fractionalIdx = slicedMatches.findIndex(function (v) { return /\./.test(v || ""); });
+    if (fractionalIdx !== -1) {
+        var lastPresentIdx = slicedMatches.reduce(function (acc, v, idx) { return (v != null ? idx : acc); }, -1);
+        var fractionalCount = slicedMatches.filter(function (v) {
+            return /\./.test(v || "");
+        }).length;
+        if (fractionalCount > 1 || fractionalIdx !== lastPresentIdx) {
+            throw new RangeError("only the smallest unit can be fractional");
+        }
     }
     return slicedMatches.reduce(function (prev, next, idx) {
         prev[objMap[idx]] = parseFloat(next || "0") || 0;

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,10 +50,7 @@ var parse = function (durationString) {
     var fractionalIdx = slicedMatches.findIndex(function (v) { return /\./.test(v || ""); });
     if (fractionalIdx !== -1) {
         var lastPresentIdx = slicedMatches.reduce(function (acc, v, idx) { return (v != null ? idx : acc); }, -1);
-        var fractionalCount = slicedMatches.filter(function (v) {
-            return /\./.test(v || "");
-        }).length;
-        if (fractionalCount > 1 || fractionalIdx !== lastPresentIdx) {
+        if (fractionalIdx !== lastPresentIdx) {
             throw new RangeError("only the smallest unit can be fractional");
         }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,10 +67,7 @@ export const parse = (durationString: string): Duration => {
       (acc, v, idx) => (v != null ? idx : acc),
       -1,
     );
-    const fractionalCount = slicedMatches.filter((v) =>
-      /\./.test(v || ""),
-    ).length;
-    if (fractionalCount > 1 || fractionalIdx !== lastPresentIdx) {
+    if (fractionalIdx !== lastPresentIdx) {
       throw new RangeError("only the smallest unit can be fractional");
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,9 +60,19 @@ export const parse = (durationString: string): Duration => {
   if (slicedMatches.filter((v) => v != null).length === 0) {
     throw new RangeError(`invalid duration: ${durationString}`);
   }
-  // Check only one fraction is used
-  if (slicedMatches.filter((v) => /\./.test(v || "")).length > 1) {
-    throw new RangeError("only the smallest unit can be fractional");
+  // A fraction is only allowed on the last present (smallest) unit
+  const fractionalIdx = slicedMatches.findIndex((v) => /\./.test(v || ""));
+  if (fractionalIdx !== -1) {
+    const lastPresentIdx = slicedMatches.reduce(
+      (acc, v, idx) => (v != null ? idx : acc),
+      -1,
+    );
+    const fractionalCount = slicedMatches.filter((v) =>
+      /\./.test(v || ""),
+    ).length;
+    if (fractionalCount > 1 || fractionalIdx !== lastPresentIdx) {
+      throw new RangeError("only the smallest unit can be fractional");
+    }
   }
 
   return slicedMatches.reduce((prev, next, idx) => {

--- a/test/iso8601-tests.mjs
+++ b/test/iso8601-tests.mjs
@@ -52,6 +52,9 @@ const relativeDate = new Date();
   "P0.5M", // invalid duration, cant have fractions in year/month/day
   "P0.5D", // invalid duration, cant have fractions in year/month/day
   "PT0,2H0,1S", // only smallest number can be fractional
+  "PT1.5H30M", // fraction on hours but minutes follow
+  "PT1.5H1S", // fraction on hours but seconds follow
+  "PT0.5M30S", // fraction on minutes but seconds follow
 ].forEach((value) => {
   test(`Validate !ok duration (${value}) against Temporal.Duration`, () => {
     const errExpected = tryCatch(() => Temporal.Duration.from(value));


### PR DESCRIPTION
## Problem

`parse()` accepts a decimal fraction on a non-final unit. These inputs are fully consumed (no trailing garbage) and wrongly accepted on current `master`:

| input | expected | current result |
|---|---|---|
| `PT1.5H30M` | invalid (fraction on hours, but minutes follow) | `{ hours: 1.5, minutes: 30 }` |
| `PT1.5H1S` | invalid (fraction on hours, but seconds follow) | `{ hours: 1.5, seconds: 1 }` |
| `PT0.5M30S` | invalid (fraction on minutes, but seconds follow) | `{ minutes: 0.5, seconds: 30 }` |

ISO 8601 allows a decimal fraction only on the smallest (last) value present in the representation. This is also the rule stated in the README ("Fractions are allowed on the smallest unit in the string ... but not `PT0.5M0.1S`") and enforced by `Temporal.Duration.from`, the oracle the test suite validates against. Temporal rejects all three inputs above with `only the smallest unit can be fractional`.

## Cause

The `timePattern` regex allows a fraction on every H/M/S group independently, so the positional rule has to be enforced in code. The existing guard only rejected when two or more groups carried a fraction:

```js
if (slicedMatches.filter((v) => /\./.test(v || "")).length > 1) {
  throw new RangeError("only the smallest unit can be fractional");
}
```

It never checks that a lone fractional group is the last present (non-null) group, so a single fraction on hours/minutes with later units present slips through.

## Fix

When a fractional group exists, require it to be the last present group (and still reject more than one fraction). Same `RangeError` message and throw behaviour as before.

## Tests

Added three cases (`PT1.5H30M`, `PT1.5H1S`, `PT0.5M30S`) to the existing invalid-duration table, which asserts against `Temporal.Duration.from`. They fail on `master` (the bad inputs are accepted) and pass with this change. The full existing suite stays green (30/30 before, 33/33 after). The substring-embedding usage example is unaffected.

By-design behaviours left untouched: substring matching of durations embedded in larger text (the documented usage example relies on it), `P0.5D` / `P0.5Y` rejection (asserted invalid in the suite), and sign handling (noted as unsupported in the README).
